### PR TITLE
More async and an INDI converter module

### DIFF
--- a/example_clients/pmacmmirs.py
+++ b/example_clients/pmacmmirs.py
@@ -315,21 +315,6 @@ async def test():
                 "detenttol",
 
         ))
-    
-#    try:
-#        now = datetime.datetime.now()
-#        fname = now.strftime("%d%b%Y-%H%M%S.pkl")
-#        with open(fname, 'wb') as pkl:
-#            pickle.dump( df, pkl )
-#    except Exception as error:
-#        print(error)
-#
-#    try:
-#        await pmac.run("filter1Wheel", 'Y')
-#        await pmac.run("filter2Wheel", 'HK3')
-#        await pmac.run("grismWheel", 'H3000')
-#    except Exception as error:
-#        print('Error')
 
     return df
 

--- a/example_clients/pmacmmirs.py
+++ b/example_clients/pmacmmirs.py
@@ -1,0 +1,254 @@
+from pathlib import Path
+import asyncio
+import sys
+import numpy as np
+sys.path.insert(0, str(Path.cwd()))
+import pandas as pd
+import time
+import datetime
+import pickle
+import os
+
+
+from saomsg.client import Subscriber
+
+
+async def main(wheel, goto):
+
+    
+
+    pmac = Subscriber(host="fields", port=10100)
+    pows = Subscriber(host="fields", port=10101)
+    await pmac.open()
+    await pows.open()
+
+    tsk1 = asyncio.create_task( pmac.mainloop() )
+    tsk2 = asyncio.create_task( pows.mainloop() )
+    await asyncio.sleep(1.0)
+
+    positions = {}
+    for number in range(1, 7):
+        name = await pmac.get(f"{wheel}Names{number}")
+        pos = await pmac.get(f"{wheel}Pos{number}")
+        positions[number] = (name, pos)
+
+    msg_vars = (
+            "Pos", 
+            "HLimBit",
+            "ULimBit",
+            )
+
+    for v in (msg_vars):
+
+        pmac.subscribe(f"{wheel}{v}", p)
+
+    await asyncio.sleep(0.5)
+
+    #tsk2 = asyncio.create_task( s.run("filter2Wheel", pos, "Abs") )
+    resp = await pmac.run( wheel, goto, timeout=30.0 )
+
+    print(resp)
+
+
+    await pmac.stop()
+    await pows.stop()
+    await tsk1
+    await tsk2
+
+
+
+
+async def test():
+
+    wheels = (
+            "filter1Wheel",
+            "filter2Wheel",
+            "grismWheel",
+            )
+
+    positions = [60, 120, 180, 240, 300, 360]
+    pmac = Subscriber(host="fields", port=10100)
+    await pmac.open()
+
+
+    tsk1 = asyncio.create_task( pmac.mainloop() )
+
+    await asyncio.sleep(1.0)
+
+
+    
+    data = []
+    start = time.time()
+
+    for target in positions:
+        for wheel in wheels:
+            testpos = np.linspace(target-1, target+1, 50)
+            print(f"Moving {wheel} to target {target}")
+
+            for pos in testpos:
+                pos = pos%360
+
+                await pmac.run('filter1Wheel', 'H3000')
+                print(f"moved {wheel} to test position {pos}")
+                p = await pmac.get(f"{wheel}Pos")
+                h =await pmac.get(f"{wheel}HLimBit")
+                m = await pmac.get(f"{wheel}MLimBit")
+                
+                awaylima = await pmac.get(f"{wheel}DetentAwayLimA")
+                awaylimb = await pmac.get(f"{wheel}DetentAwayLimB")
+                awaylima = await pmac.get(f"{wheel}DetentAwayLimA")
+                awaylimb = await pmac.get(f"{wheel}DetentAwayLimB")
+
+                nearlima = await pmac.get(f"{wheel}DetentNearLimA")
+                nearlimb = await pmac.get(f"{wheel}DetentNearLimB")
+                nearlima = await pmac.get(f"{wheel}DetentNearLimA")
+                nearlimb = await pmac.get(f"{wheel}DetentNearLimB")
+
+                swhistaway = await pmac.get(f"{wheel}SwitchHistAway")
+                swhistnear = await pmac.get(f"{wheel}SwitchHistNear")
+
+                detenttola = await pmac.get(f"{wheel}DetentTolA")
+                detenttolb = await pmac.get(f"{wheel}DetentTolB")
+
+                detenttol = await pmac.get(f"{wheel}DetentTol")
+                now = time.time()-start
+
+                data.append((
+                    now, 
+                    float(p[0]), 
+                    int(h[0]), 
+                    int(m[0]), 
+                    wheel, 
+                    "positive", 
+                    float(awaylima[0] ),
+                    float(awaylimb[0] ),
+                    float(awaylima[0] ),
+                    float(awaylimb[0] ),
+
+                    float(nearlima[0] ),
+                    float(nearlimb[0] ),
+                    float(nearlima[0] ),
+                    float(nearlimb[0] ),
+
+                    float(swhistaway[0] ),
+                    float(swhistnear[0] ),
+
+                    float(detenttola[0] ),
+                    float(detenttolb[0] ),
+
+                    float(detenttol[0] ),
+                    
+                    ))
+                break
+            break
+            
+            await pmac.run(wheel, target+5, "Abs")
+
+            for pos in reversed(testpos):
+                pos = pos%360
+                await pmac.run(wheel, pos, "Abs")
+                print(f"moved {wheel} to test position {pos}")
+                p = await pmac.get(f"{wheel}Pos")
+                h = await pmac.get(f"{wheel}HLimBit")
+                m = await pmac.get(f"{wheel}MLimBit")
+                awaylima = await pmac.get(f"{wheel}DetentAwayLimA")
+                awaylimb = await pmac.get(f"{wheel}DetentAwayLimB")
+                awaylima = await pmac.get(f"{wheel}DetentAwayLimA")
+                awaylimb = await pmac.get(f"{wheel}DetentAwayLimB")
+
+                nearlima = await pmac.get(f"{wheel}DetentNearLimA")
+                nearlimb = await pmac.get(f"{wheel}DetentNearLimB")
+                nearlima = await pmac.get(f"{wheel}DetentNearLimA")
+                nearlimb = await pmac.get(f"{wheel}DetentNearLimB")
+
+                swhistaway = await pmac.get(f"{wheel}SwitchHistAway")
+                swhistnear = await pmac.get(f"{wheel}SwitchHistNear")
+
+                detenttola = await pmac.get(f"{wheel}DetentTola")
+                detenttolb = await pmac.get(f"{wheel}DetentTolB")
+
+                detenttol = await pmac.get(f"{wheel}DetentTol")
+                now = time.time()-start
+
+                now = time.time()-start
+
+                data.append((
+                    now, 
+                    float(p[0]), 
+                    int(h[0]), 
+                    int(m[0]), 
+                    wheel, 
+                    "positive", 
+                    float(awaylima[0] ),
+                    float(awaylimb[0] ),
+                    float(awaylima[0] ),
+                    float(awaylimb[0] ),
+
+                    float(nearlima[0] ),
+                    float(nearlimb[0] ),
+                    float(nearlima[0] ),
+                    float(nearlimb[0] ),
+
+                    float(swhistaway[0] ),
+                    float(swhistnear[0] ),
+
+                    float(detenttola[0] ),
+                    float(detenttolb[0] ),
+
+                    float(detenttol[0] ),
+                    
+                    ))
+
+
+        break
+    df = pd.DataFrame(data, 
+        columns=("time", "pos", "h", 'm', 'wheel',
+        'direction',
+
+                "awaylima",
+                "awaylimb",
+                "awaylima",
+                "awaylimb",
+
+                "nearlima",
+                "nearlimb",
+                "nearlima",
+                "nearlimb",
+
+                "swhistaway",
+                "swhistnear",
+
+                "detenttola",
+                "detenttolb",
+
+                "detenttol",
+
+        ))
+    
+#    try:
+#        now = datetime.datetime.now()
+#        fname = now.strftime("%d%b%Y-%H%M%S.pkl")
+#        with open(fname, 'wb') as pkl:
+#            pickle.dump( df, pkl )
+#    except Exception as error:
+#        print(error)
+#
+#    try:
+#        await pmac.run("filter1Wheel", 'Y')
+#        await pmac.run("filter2Wheel", 'HK3')
+#        await pmac.run("grismWheel", 'H3000')
+#    except Exception as error:
+#        print('Error')
+
+    return df
+
+async def p(val):
+    await asyncio.sleep(0.05)
+    print(val)
+
+
+import sys
+print(sys.argv)
+#asyncio.run(main(*sys.argv[1:]))
+#asyncio.run(test())
+

--- a/example_clients/pmacmmirs.py
+++ b/example_clients/pmacmmirs.py
@@ -8,7 +8,7 @@ import time
 import datetime
 import pickle
 import os
-
+from collections import OrderedDict
 
 from saomsg.client import Subscriber
 
@@ -54,6 +54,97 @@ async def main(wheel, goto):
     await pows.stop()
     await tsk1
     await tsk2
+
+
+
+
+async def goto(wheel, Filter):
+
+    pmac = Subscriber(host="fields", port=10100)
+    await pmac.open()
+
+
+    tsk1 = asyncio.create_task( pmac.mainloop() )
+    wheels = OrderedDict(
+            filter1Wheel =\
+                [
+                    "Y",
+                    "J", 
+                    "Kspec", 
+                    "K", 
+                    "H", 
+                    "open"
+                    ],
+            filter2Wheel=\
+                [
+                    "HK3",
+                    "open",
+                    "dark", 
+                    "HK", 
+                    "zJ"
+                    ],
+            grismWheel=\
+                [
+                    "H3000", 
+                    "H", 
+                    "HK", 
+                    "J", 
+                    "K3000", 
+                    "open",
+                    ]
+            )
+
+    gettables = [
+#            "Pos",
+#            "HLimBit",
+#            "MLimBit",
+            "DetentAwayLimA",
+            "DetentAwayLimB",
+            "DetentAwayLimA",
+            "DetentAwayLimB",
+            "DetentNearLimA",
+            "DetentNearLimB",
+            "DetentNearLimA",
+            "DetentNearLimB",
+            "SwitchHistAway",
+            "SwitchHistNear",
+            "DetentTolA",
+            "DetentTolB",
+            "DetentTol"
+            ]
+
+
+    rows = []
+    print("starting")
+    print("Stopping")
+    #for wheel, optic in wheels.items():
+    for a in [1]:
+        
+        row = []
+        print(wheel)
+        await pmac.run(wheel, Filter)
+        for param_name in gettables:
+            print(f"{wheel}{param_name}")
+            value = await pmac.get(f"{wheel}{param_name}")
+            print(f"{param_name}\t {value[0]}")
+            row.append(value[0])
+        row+=[wheel, Filter]
+        rows.append(row)
+
+        break 
+    print(gettables+[wheel])
+    print(rows)
+    await pmac.stop()
+
+    return pd.DataFrame(
+            rows, 
+            columns=gettables+['wheel', 'filter'],
+            index=[int(time.time())])
+
+
+
+       
+
 
 
 

--- a/example_clients/waveserv.py
+++ b/example_clients/waveserv.py
@@ -176,6 +176,8 @@ class WAVESERV(msg_device):
         Defines INDI numbers relating to axis
         position.
         """
+        #TODO puntino was removed in the early 2000's and replaced
+        # With stellacam. The software should reflect this. 
         axes = ("mirror", "trans", "select", "focus", "puntino")
         pos_types = ("actual", "commanded", "target")
 
@@ -499,7 +501,10 @@ class WAVESERV(msg_device):
 
 
     @MSG.subscribe("WAVESERV","pA", "pt")
-    def on_puntino_change(self, item, value ):
+    def on_stellacam_change(self, item, value ):
+        """
+
+        """
         vec = self.IUFind("puntino")
         if item == "pA":
             vec["actual"].value = float(value[0])

--- a/example_clients/waveserv.py
+++ b/example_clients/waveserv.py
@@ -11,7 +11,18 @@ import os
 
 
 class WAVESERV(msg_device):
+    """
+    The msg to indi converter for the WFS/F5.
+    
+    """
 
+    ####################################
+    #INDI Vector property definitions
+    #
+    # This set of methods define INDI 
+    # Properties for the attributes of 
+    # the waveserv msg server.
+    # 
     def power_switches(self):
         """
         Define the INDI swithes related to power.
@@ -88,7 +99,7 @@ class WAVESERV(msg_device):
                     label=k,
                     name=k,
                     state="Idle",
-                    perm="ro",
+                    perm="rw",
                     group="Registered Fxns"
                 ),
                 [
@@ -207,6 +218,10 @@ class WAVESERV(msg_device):
 
 
     def axis_details(self):
+        """
+        Define other INDI vector properties related
+        to the axes. 
+        """
 
         axis_map = dict(
             mirror=('m', 1),
@@ -322,10 +337,22 @@ class WAVESERV(msg_device):
                 props2.append(prop)
             vec = self.vectorFactory("Number", vec_att2, props2)
             self.IDDef(vec)
+    #END Vector Property definitions
+    ##################################
+    
 
-            
+    ################################
+    #MSG subscription handlers
+    # thses methods are called when the
+    # listed MSG variables are sent from the
+    # MSG server. They usually update an INDI 
+    # Vector property
     @MSG.subscribe("p70","p71","p72","p73","p74","p75")
     def on_special_pos_change(self, item, value):
+        """
+        Called when we get a new message for any of the 
+        special positions. Updates the indi vector accordingly. 
+        """
         vec = self.IUFind("special_positions")
         vec[item].value = float(value[0])
         self.IDSet(vec)
@@ -604,8 +631,8 @@ class WAVESERV(msg_device):
         temps[item].value = float(value[0])
         self.IDSet(temps)
 
-    
-       
+    #END MSG subscription handlers
+    #########################################
 
 async def main():    
     hostport = os.environ.get("INDICONFIG", )

--- a/example_clients/waveserv.py
+++ b/example_clients/waveserv.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+from saomsg.msgtoindi import msg_device
+from saomsg.msgtoindi import wrapper as MSG
+
+from saomsg.client import Subscriber
+from pyindi.client import INDIClient
+import asyncio
+import logging
+logging.getLogger().setLevel(logging.DEBUG)
+import os
+
+
+class WAVESERV(msg_device):
+
+    def power_switches(self):
+        """
+        Define the INDI swithes related to power.
+        """
+        vec_att = dict(
+                    device=self.device,
+                    name="power",
+                    label='Power',
+                    group="Main",
+                    rule="AnyOfMany",
+                    perm="rw",
+                    state="Idle"
+
+                )
+
+        switches = []
+        names = ("epower", "spower", "ppower", "fpower", "apower", "bpower")
+        labels = ("Encoder", "Servo", "Puntino", "Stellacam", "Apogee", "SBIG")
+        for name, label in zip(names, labels):
+            switches.append(dict(
+                    name=name,
+                    label=label,
+                    state="Off"
+                    ))
+
+        vec = self.vectorFactory("Switch", vec_att, switches)
+        self.IDDef(vec)
+
+
+    def temps_numbers(self):
+        """
+        Define the INDI numbers related to temperature.
+        """
+        vec_att = dict(
+                device=self.device,
+                name="temps",
+                label="Temps",
+                group="Main",
+                state="Idle",
+                perm="ro",
+                )
+        names = dict(
+                mMTemp="Mirror Motor Temp",
+                tMTemp="Trans Motor Temp",
+                cMTemp="Camera Motor Temp",
+                fMTemp="Focus Motor Temp",
+                mSTemp="Mirror Struct Temp",
+                tSTemp="Trans Struct Temp",
+                cSTemp="Camera Struct Temp",
+                fSTemp="Focus Struct Temp",
+                cpuTemp="CPU Temp",
+                vTemp="vTemp"
+                )
+        numbers=[]
+        for name, label in names.items():
+            numbers.append(dict(
+                name=name,
+                label=label,
+                min=-10000,
+                max=10000,
+                step=0.01,
+                value=0,
+                format="%8.2f"
+                ))
+        vec = self.vectorFactory("Number", vec_att, numbers)
+        self.IDDef(vec)
+
+    def registered_texts(self):
+        for k in self.msg_client.server_info['registered']:
+            vec = self.vectorFactory(
+                "Text",
+                dict(
+                    device=self.device,
+                    label=k,
+                    name=k,
+                    state="Idle",
+                    perm="ro",
+                    group="Registered Fxns"
+                ),
+                [
+                dict(
+                    name=k,
+                    label=k,
+                    text=k
+                )
+                ]
+
+            )
+            self.IDDef(vec)
+
+    def axis_switches(self):
+        """
+        Define the axis switch for abort, clear, busy and estop
+        """
+
+        act_attr = dict(
+                device=self.device,
+                name="axis_actions",
+                label="Axis Actions",
+                state="Idle",
+                perm="rw",
+                group="Main",
+                rule="AnyOfMany"
+                )
+        act_switches = [
+                dict(
+                    name="abort",
+                    label="Abort",
+                    state="Off"
+                    ), 
+
+                dict(
+                    name="clear",
+                    label="Clear",
+                    state="Off"
+                    ),
+                ]
+
+        vec = self.vectorFactory( "Switch",  act_attr, act_switches)
+
+        self.IDDef(vec)
+        state_attr = dict( 
+                device=self.device,
+                name="axis_states",
+                label="Axis States",
+                state="Idle",
+                perm="ro",
+                group="Main",
+                rule="AnyOfMany"
+                )
+        
+        state_switches = [
+                 dict(
+                    name="busy",
+                    label="Busy",
+                    state="Off"
+                    ), 
+
+                dict(
+                    name="estop",
+                    label="E-Stop",
+                    state="Off"
+                    ),
+                    ]
+
+        logging.debug(f"Defining states")
+        self.IDDef(
+                self.vectorFactory(
+                    "Switch", 
+                    state_attr, 
+                    state_switches)
+                )
+       
+
+    def axis_numbers(self):
+        """
+        Defines INDI numbers relating to axis
+        position. 
+        """
+        axes = ("mirror", "trans", "select", "focus", "puntino")
+        pos_types = ("actual", "commanded", "target")
+
+        for axis in axes:
+            att = dict(
+                    device=self.device,
+                    name=axis,
+                    label=axis,
+                    state="Idle",
+                    perm="ro",
+                    group="Main"
+                    
+                    )
+            props = []
+            for pos in pos_types:
+                if axis=="puntino" and pos == "commanded":
+                    continue
+                props.append(dict( 
+                    name=pos,
+                    label=pos,
+                    min=-10000,
+                    max=10000,
+                    step=0.01,
+                    value=0,
+                    format="%8.2f",
+
+                    ))
+            vec = self.vectorFactory(
+                    "Number", 
+                    att,
+                    props
+                    )
+            self.IDDef(vec)
+
+
+    def axis_details(self):
+
+        axis_map = dict(
+            mirror=('m', 1),
+            trans= ('t', 2),
+            camera=('c', 3),
+            focus= ('f', 4),
+            )
+
+        prop_defaults = dict(min=-100000, max=100000, step=0.01, format="%8.3f", value=0)
+        special_positions = dict( 
+                p70="WFS Position",
+                p71="Sci Position",
+                p72="WFS T Offset",
+                p73="Sci T Offset",
+                p74="WFS F Offset",
+                p75="Sci F Offset"
+                )
+        props = []
+        for name,label in special_positions.items():
+            prop = dict(
+                    name=name,
+                    label=label
+                    )
+            prop.update(prop_defaults)
+            props.append(prop)
+
+        vec = self.vectorFactory("Number",
+                dict(
+                    device=self.device,
+                    name="special_positions",
+                    label="Special Positions",
+                    state="Idle",
+                    perm="ro",
+                    group="Special Positions"
+                    ),
+                props
+                )
+        self.IDDef(vec)
+
+        for name, (letter, number) in axis_map.items():
+
+            pnames = {
+                    f"{letter}E"      : "Encoder Scale",
+                    f"{letter}MlimPos": "Limit of Pos. Travel",
+                    f"{letter}PlimPos": "Limit of Neg. Travel",
+                    f"{letter}HomePos": "Encoder Home",
+                    f"{letter}DAC"    : "DAC Value",
+                    f"{letter}DACBias": "DAC Bias",
+                    }
+                    
+            vec_att = dict(
+                    device=self.device,
+                    name=f"{name}_details",
+                    state="Idle",
+                    perm="ro",
+                    label=f"{name} Details",
+                    group=f"{name} Details"
+                    )
+
+            props =[]
+            for pname, label in pnames.items():
+                prop = dict(
+                        name=pname,
+                        label=label
+                        )
+                prop.update(prop_defaults)
+                props.append(prop)
+
+            vec = self.vectorFactory("Number", vec_att, props)
+            self.IDDef(vec)
+
+            pnames2 = {
+                    f"i{number}30"  :   "Proportional Gain",
+                    f"i{number}31"  :   "Derivative Gain",
+                    f"i{number}32"  :   "Veclocity Feed Forward",
+                    f"i{number}33"  :   "Integral Gain",
+                    f"i{number}63"  :   "Integration Limit",
+                    f"i{number}67"  :   "Big Step Limit",
+
+                    f"p{number}05"    :   "Feed Rate",
+                    f"p{number}06"    :   "Time of Acceleration",
+                    f"p{number}07"    :   "Time of S-Curve",
+                    f"p{number}02"    :   "Home Speed",
+                    f"p{number}03"    :   "Home Offset",
+
+                    f"i{number}16"    :   "Maximum Velocity",
+                    f"i{number}17"    :   "Maximum Acceleration",
+
+                    f"p{number}08"    :   "Position Tolerance",
+
+                    f"i{number}11"    :   "Following Error",
+                    f"i{number}95"    :   "Hold Decel Rate",
+                    f"i{number}15"    :   "Error Deceleration Rate",
+                    f"i{number}64"    :   "Dead Band Factor",
+                    f"i{number}65"    :   "Dead Band Size"
+                    }
+
+            vec_att2 = dict(
+                    device=self.device,
+                    name=f"{name}_servo",
+                    state="Idle",
+                    perm="ro",
+                    label=f"{name} Servo",
+                    group=f"{name} Details"
+                    )
+            props2 = []
+            for pname, label in pnames2.items():
+                prop = dict(
+                        name=pname,
+                        label=label
+                        )
+                prop.update(prop_defaults)
+                props2.append(prop)
+            vec = self.vectorFactory("Number", vec_att2, props2)
+            self.IDDef(vec)
+
+            
+    @MSG.subscribe("p70","p71","p72","p73","p74","p75")
+    def on_special_pos_change(self, item, value):
+        vec = self.IUFind("special_positions")
+        vec[item].value = float(value[0])
+        self.IDSet(vec)
+
+
+    @MSG.subscribe("WAVESERV", 
+            "mE", "mMlimPos", "mplimPos", "mHomePos","mDAC", "mDACBias")
+    def on_mirror_details_change(self, item, value):
+        self.IDMessage(f"mirror details called {item}={value}")
+        vec = self.IUFind("mirror_details")
+
+        value = float(value[0])
+        vec[item].value = value
+        self.IDSet(vec)
+
+
+    @MSG.subscribe("WAVESERV", 
+             "i130","i131","i132","i133","i163","i167",
+             "p105","p106","p107","p102","p103",
+             "i116","i117",
+             "p108",
+             "i111","i195","i115","i164","i165")
+    def on_mirror_servo_change(self, item, value):
+        vec = self.IUFind("mirror_servo")
+
+        value = float(value[0])
+        vec[item].value = value
+        self.IDSet(vec)
+       
+
+    @MSG.subscribe("WAVESERV","mA","mC","mT")
+    def on_mirror_change(self, item, value ):
+        """
+        Called when MSG server updates the 
+        mirror position. Updates the corresponding 
+        INDI numbers. 
+        """
+        vec = self.IUFind("mirror")
+        if item == "mA":
+            vec["actual"].value = float(value[0])
+        elif item == "mC":
+            vec["commanded"].value = float(value[0])
+        elif item == "mT":
+            vec["target"].value = float(value[0])
+
+        self.IDSet(vec)
+
+
+    @MSG.subscribe("WAVESERV","tA","tC","tT",)
+    def on_trans_change(self, item, value ):
+        vec = self.IUFind("trans")
+        if item == "tA":
+            vec["actual"].value = float(value[0])
+        elif item == "tC":
+            vec["commanded"].value = float(value[0])
+        elif item == "tT":
+            vec["target"].value = float(value[0])
+   
+        self.IDSet(vec)
+
+    @MSG.subscribe("WAVESERV", 
+            "tE", "tMlimPos", "tplimPos", "tHomePos","tDAC", "tDACBias")
+    def on_trans_details_change(self, item, value):
+        vec = self.IUFind("trans_details")
+
+        value = float(value[0])
+        vec[item].value = value
+        self.IDSet(vec)
+
+
+    @MSG.subscribe("WAVESERV", 
+             "i230","i231","i232","i233","i263","i267",
+             "p205","p206","p207","p202","p203",
+             "i216","i217",
+             "p208",
+             "i211","i295","i215","i264","i265")
+    def on_trans_servo_change(self, item, value):
+        vec = self.IUFind("trans_servo")
+
+        value = float(value[0])
+        vec[item].value = value
+        self.IDSet(vec)
+
+
+    @MSG.subscribe("WAVESERV","fA","fC","fT",)
+    def on_focus_change(self, item, value ):
+        vec = self.IUFind("focus")
+        if item == "fA":
+            vec["actual"].value = float(value[0])
+        elif item == "fC":
+            vec["commanded"].value = float(value[0])
+        elif item == "fT":
+            vec["target"].value = float(value[0])
+   
+        self.IDSet(vec)
+
+
+    @MSG.subscribe("WAVESERV", 
+            "fE", "fMlimPos", "fplimPos", "fHomePos","fDAC", "fDACBias")
+    def on_focus_details_change(self, item, value):
+        vec = self.IUFind("focus_details")
+
+        value = float(value[0])
+        vec[item].value = value
+        self.IDSet(vec)
+
+
+    @MSG.subscribe("WAVESERV", 
+             "i430","i431","i432","i433","i463","i467",
+             "p405","p406","p407","p402","p403",
+             "i416","i417",
+             "p408",
+             "i411","i495","i415","i464","i465")
+    def on_focus_servo_change(self, item, value):
+        vec = self.IUFind("focus_servo")
+
+        value = float(value[0])
+        vec[item].value = value
+        self.IDSet(vec)
+
+
+
+    @MSG.subscribe("WAVESERV","cA","cC","ct",)
+    def on_camera_change(self, item, value ):
+        vec = self.IUFind("select")
+        if item == "cA":
+            vec["actual"].value = float(value[0])
+        elif item == "cC":
+            vec["commanded"].value = float(value[0])
+        elif item == "ct":
+            vec["target"].value = float(value[0])
+   
+        self.IDSet(vec)
+
+
+    @MSG.subscribe("WAVESERV", 
+            "cE", "cMlimPos", "cplimPos", "cHomePos","cDAC", "cDACBias")
+    def on_camera_details_change(self, item, value):
+        vec = self.IUFind("camera_details")
+
+        value = float(value[0])
+        vec[item].value = value
+        self.IDSet(vec)
+
+
+    @MSG.subscribe("WAVESERV", 
+             "i330","i331","i332","i333","i363","i367",
+             "p305","p306","p307","p302","p303",
+             "i316","i317",
+             "p308",
+             "i311","i395","i315","i364","i365")
+    def on_camera_servo_change(self, item, value):
+        vec = self.IUFind("camera_servo")
+
+        value = float(value[0])
+        vec[item].value = value
+        self.IDSet(vec)
+
+
+
+    @MSG.subscribe("WAVESERV","pA", "pt")
+    def on_puntino_change(self, item, value ):
+        vec = self.IUFind("puntino")
+        if item == "pA":
+            vec["actual"].value = float(value[0])
+        elif item == "pt":
+            vec["target"].value = float(value[0])
+   
+        self.IDSet(vec)
+
+
+
+
+    async def buildProperties(self):
+        await super().buildProperties()
+
+        self.power_switches()
+        self.temps_numbers()
+        self.axis_switches()
+        self.axis_numbers()
+        self.axis_details()
+        try:
+            self.registered_texts()
+        except Exception as error:
+            logging.debug(f"registered details has this error: {error}")
+
+    @msg_device.NewVectorProperty("epower_switch")
+    def epower(self, device, name, states, names):
+        vec, change = self.whats_changed(
+                name, 
+                states, 
+                values
+                )
+        
+        for name, newval in change.items():
+            self.IDMessage(f"{name} changed to {newval}")
+            vec[name].value = newval
+
+        self.IDSet(vec)
+
+    
+    @MSG.subscribe("WAVESERV", "abort", "clear", "busy", "estop")
+    def on_axis_change(self, item, value):
+        acts = self.IUFind("axis_actions")
+        states = self.IUFind("axis_states")
+        value = int(value[0])
+
+        if value == 1:
+            value = "On"
+        elif value == 0:
+            value = "Off"
+        else:
+            raise ValueError(f"Value of {item} must be 0 or 1 not {value}")
+
+        if item in ("busy", "estop"):
+            states[item].value = value
+
+        elif item in ("abort", "clear"):
+            states[item].value = value
+
+
+    @MSG.subscribe("WAVESERV", 
+            "epower", # Encoder
+            "spower", # Servo
+            "ppower", # Puntino
+            "bpower", # sbig power
+            "apower", # apogee power
+            "fpower"  # StellaCam
+            )
+    def on_power_change(self, item, value):
+        """
+        This method is called whenever one of the
+        power states are published from the MSG
+        server. 
+
+        args:
+        item => Name of power msg value
+        value => new value of the power item. 
+
+        """
+        power = self.IUFind("power")
+        #changed = self.whats_changed(power)
+        self.IDMessage(f"power state change: {item} {value}")
+
+        if type(value) == list:
+            value = value[0]
+        value = int(value)
+        if value == 0:
+            power[item].value = "Off"
+
+        elif value == 1:
+            power[item].value = "On"
+        else:
+            raise ValueError(
+                    f"Power value of {item} should be '0' or '1' not {value}"
+                    )
+
+        self.IDSet(power)
+
+
+    @MSG.subscribe("WAVESERV", 
+            "mMtemp",
+            "tMTemp",
+            "cMTemp",
+            "fMTemp",
+            "mSTemp",
+            "tSTemp",
+            "cSTemp",
+            "fSTemp",
+            "cpuTemp",
+            "vTemp"
+            )
+    def on_temps(self, item, value):
+        temps = self.IUFind("temps")
+        self.IDMessage(f"{item} changed to {value}")
+        temps[item].value = float(value[0])
+        self.IDSet(temps)
+
+    
+       
+
+async def main():    
+    hostport = os.environ.get("INDICONFIG", )
+    device_name = os.environ.get("INDIDEV", )
+    if hostport is None:
+        host,port = "wavefront.mmto.arizona.edu", 3000
+    else:
+        host,port = hostport.split(':')
+    m=WAVESERV(host, int(port), device_name)
+    await m.astart()
+
+
+
+asyncio.run(main())
+

--- a/saomsg/client.py
+++ b/saomsg/client.py
@@ -233,7 +233,7 @@ class Subscriber(MSGClient):
 
     def subscribe(self, param, callback=None):
 
-        """Subscribe to a msg variable with optional callback the
+        """Subscribe to a msg variable with optional callback. The
         callback should be a coroutine that excepts the value of
         the variable as its only argument. The Callback should not
         be CPU intensive or we will bog down the mainloop. If we
@@ -265,12 +265,12 @@ class Subscriber(MSGClient):
     async def mainloop(self, timeout=None):
         """ Read and handle data from msg server.
         """
-        
+
         if not self.running:
             raise RuntimeError("Must call open() before mainloop()")
 
         rawdata = b''
-        
+
         while self.running:
             logging.debug("reading data")
             try:
@@ -332,13 +332,12 @@ class Subscriber(MSGClient):
 
             else:
                 # TODO
-                # When you subscribe to a variable the server 
+                # When you subscribe to a variable the server
                 # Imediately responds with an ack and the inital value.
                 # We currently Don't have a means of capturing this
                 # value so it is gracefully ignored. We need to
                 # find a way to capture it and apply the callback.
                 logging.warn(f"gracefully ignoring {acknak}")
-
 
     async def stop(self):
         self.running = False

--- a/saomsg/client.py
+++ b/saomsg/client.py
@@ -1,5 +1,58 @@
 import asyncio
+import time
+import inspect
+from dataclasses import dataclass
+import typing
 
+@dataclass
+class MSG:
+       msgid: typing.Union[int, None]
+
+@dataclass
+class SET(MSG):
+    param: str
+    value: typing.Any
+
+
+@dataclass
+class ACK(MSG):
+    args: tuple
+
+@dataclass
+class NAK(MSG):
+    info: str
+
+
+def msg_factory(data:str):
+    vals = data.split()
+
+    if vals[0].isnumeric():
+        msgid = int(vals[0])
+        Type = vals[1]
+        argindex = 2
+
+    else:
+        msgid = None
+        Type = vals[0]
+        argindex = 1
+        
+
+
+    if Type == "set":
+        msg = SET(msgid, vals[argindex], vals[argindex+1:])
+
+    elif Type == "ack":
+        msg = ACK(msgid, vals[argindex:])
+
+    elif Type == "nak":
+        msg = NAK(msgid, " ".join(vals[argindex:]) )
+
+    else:
+        msg = MSG(msgid)
+        msg.info = vals[argindex:]
+
+    return msg
+   
 
 class MSGClient(object):
     """
@@ -74,6 +127,8 @@ class MSGClient(object):
         params = " ".join(str(x) for x in pars)
         msg = f"1 {command} {params}\n"
         data = await self._writemsg(msg)
+        print(data)
+
         if int(data[0]) == 1 and data[1] == "ack":
             value = True
             print(f"Successfully ran {command} with params {params}")
@@ -81,6 +136,7 @@ class MSGClient(object):
             print(f"Failed to run {command} with params {params} on MSG server")
             value = False
         return value
+
 
     async def _list(self):
         """
@@ -106,3 +162,227 @@ class MSGClient(object):
                 if 'registered' in line:
                     var = line.split()[1]
                     self.server_info['registered'].append(var)
+
+    
+
+
+
+# Subscriber class
+
+class Subscriber(MSGClient):
+
+    MAXID = 100000
+
+    async def open(self):
+        await super().open()
+        self.server_info['subscribed'] = {}
+        self.callbacks = {}
+        self.tasks = []
+        self.outstanding_replies = {}
+        self.nextid = 1
+        
+
+    def subscribe(self, param, callback=None): 
+
+        """Subscribe to a msg variable with optional callback the
+        callback should be a coroutine that excepts the value of 
+        the variable as its only argument. The Callback should not 
+        be CPU intensive or we will bog down the mainloop. If we 
+        want to do CPU bound stuff we will need to come up with a
+        way to run the callbacks in the executor. """
+        
+        msgid = self.getid()
+
+        if param not in self.server_info['published']:
+            errmsg = f"{param} not published by MSG server {self.server_info['name']}"
+            raise ValueError(errmsg)
+
+        if param not in self.server_info['subscribed']:
+            self.server_info['subscribed'][param] = None
+            if callback is not None:
+
+                self.callbacks[param] = callback
+
+            self.writer.write(f"{msgid} sub {param}\n".encode())
+
+        
+
+    def unsubscribe(self, param):
+        
+        if param in self.server_info['subscribed']:
+            msgid = self.getid()
+            del self.server_info['subscribed']
+            self.writer.write(f"{msgid} uns {param}\n".encode())
+
+
+
+
+#    def __getattr__(self, param):
+#
+#        if param in self.server_info['subscribed']:
+#            return self.server_info['subscribed'][param]
+#
+#        elif param in self.server_info['registered']:
+#            return lambda *args : self.run(param, *args)
+#
+#        else:
+#            errmsg = f"{param} not subscribed by MSG server\
+#            {self.server_info['name']} use subscribe method"
+#            raise ValueError(errmsg)
+
+
+    async def mainloop(self, timeout=None):
+        """ Read and handle data from msg server. 
+        
+        """
+        self.running=True
+        starttime = time.time()
+        rawdata = b''
+        while self.running:
+
+            try:
+                rawdata+= await asyncio.wait_for(self.reader.read(1), 5.0)
+            
+            except asyncio.TimeoutError as TO:
+                # Give us a chance to check the loop. 
+                continue
+
+            except Exception as error:
+                print(f"We have a read error: {[error]}")
+                raise error
+
+
+            data=rawdata.decode()
+
+
+            if rawdata.endswith(b'\n'):
+                rawdata = b""
+            else:
+                continue
+            
+            self.last_data = data
+            vals = data.split()
+        
+            acknak = msg_factory(data)
+
+
+        
+            if type(acknak) is SET:
+                self.server_info['subscribed'][acknak.param] = " ".join(acknak.value)
+
+                if acknak.param in self.callbacks:
+                    cb = self.callbacks[acknak.param]
+                    loop = asyncio.get_running_loop()
+                    
+                    if inspect.iscoroutinefunction( cb ):
+                        task = loop.create_task(cb(*acknak.value))
+                        self.tasks.append(task)
+
+                    else:
+                        loop.call_soon(cb, acknak.values)
+
+            elif acknak.msgid in self.outstanding_replies:
+                aq =  self.outstanding_replies[acknak.msgid]
+                if type(acknak) is ACK:
+                    reply = acknak.args
+                elif type(acknak) is NAK:
+                    reply = RuntimeError(f"{acknak.info}")
+                else:
+                    raise RuntimeError(f"Expected ack or nak not {acknak}")
+
+
+                await aq.put(reply)
+                del self.outstanding_replies[acknak.msgid]
+
+
+            else:
+                print(f"gracefully ignoring {acknak}")
+
+
+
+
+    async def stop(self):
+        self.running = False
+        for task in self.tasks:
+            task.cancel("Cancelled due to stop() being called.")
+
+        await asyncio.sleep(0.5)
+
+
+    async def run(self, command, *pars, timeout=None):
+        """
+        Implement running an MSG command. Only an 'ack' or a 'nak' are returned so
+        check that to see if command was succesful. Return True or False accordingly.
+        """
+        
+        if type(timeout) not in (float, int):
+            if timeout is not None:
+                raise ValueError(f"timeout must be float or int. Not {type(timeout)}")
+
+        if command not in self.server_info['registered']:
+            errmsg = f"{command} not registered by MSG server {self.server_info['name']}"
+            raise ValueError(errmsg)
+        params = " ".join(str(x) for x in pars)
+
+        msgid = self.getid()
+
+        aq = asyncio.Queue()
+        self.outstanding_replies[msgid] = aq
+
+
+        msg = f"{msgid} {command} {params}\n"
+
+        self.writer.write(msg.encode())
+        await self.writer.drain()
+        print("getting")
+        if timeout:
+            resp = await asyncio.wait_for( aq.get(), timeout)
+        else:
+            resp = await aq.get()
+
+        if isinstance(resp, Exception):
+            raise resp
+
+        return resp
+
+
+
+    def getid(self):
+        msgid = self.nextid
+        self.nextid+=1
+        self.nextid%=self.MAXID
+        return msgid
+
+
+    async def get(self, param):
+
+        msgid = self.getid()
+
+        aq = asyncio.Queue()
+
+        self.outstanding_replies[msgid] = aq
+        self.writer.write(f"{msgid} get {param}\n".encode())
+        await self.writer.drain()
+
+        return await aq.get()
+        
+
+
+class SubscriberSingleton:
+
+    """For most uses we probably will only ever need on
+    instance of a client per msg server. This will 
+    instantiate a Subscriber if none exist for 
+    that host and port"""
+
+    clients = {}
+
+    def __new__(cls, host, port):
+        if (host, port) not in cls.clients:
+            cls.clients[(host, port)] = Subscriber(host, port)
+
+        return cls.clients[(host, port)]
+
+async def pp(val):
+    await asyncio.sleep(0.9)
+    print(val)

--- a/saomsg/client.py
+++ b/saomsg/client.py
@@ -177,7 +177,6 @@ class MSGClient(object):
         Implement the MSG lst command and use it to populate self.server_info
         """
         msg = "1 lst\n"
-<<<<<<< HEAD
         data = await self._writemsg(msg)
         if int(data[0]) == 1 and data[1] == "ack":
             print("Successfully sent 'lst' command")

--- a/saomsg/client.py
+++ b/saomsg/client.py
@@ -265,8 +265,12 @@ class Subscriber(MSGClient):
     async def mainloop(self, timeout=None):
         """ Read and handle data from msg server.
         """
-        self.running = True
+        
+        if not self.running:
+            raise RuntimeError("Must call open() before mainloop()")
+
         rawdata = b''
+        
         while self.running:
             logging.debug("reading data")
             try:
@@ -327,7 +331,14 @@ class Subscriber(MSGClient):
                 del self.outstanding_replies[acknak.msgid]
 
             else:
+                # TODO
+                # When you subscribe to a variable the server 
+                # Imediately responds with an ack and the inital value.
+                # We currently Don't have a means of capturing this
+                # value so it is gracefully ignored. We need to
+                # find a way to capture it and apply the callback.
                 logging.warn(f"gracefully ignoring {acknak}")
+
 
     async def stop(self):
         self.running = False

--- a/saomsg/client.py
+++ b/saomsg/client.py
@@ -287,12 +287,13 @@ class Subscriber(MSGClient):
         starttime = time.time()
         rawdata = b''
         while self.running:
-
+            logging.debug("reading data")
             try:
                 rawdata+= await asyncio.wait_for(self.reader.read(1), 5.0)
             
             except asyncio.TimeoutError as TO:
                 # Give us a chance to check the loop. 
+                logging.debug(f"timeout")
                 continue
 
             except Exception as error:
@@ -302,16 +303,16 @@ class Subscriber(MSGClient):
 
             data=rawdata.decode()
 
-
             if rawdata.endswith(b'\n'):
                 rawdata = b""
             else:
                 continue
             
+            logging.debug(f"raw data is {data}")
             self.last_data = data
             vals = data.split()
-        
             acknak = msg_factory(data)
+            
 
 
             # SET is used for subscribed parameters. 
@@ -327,7 +328,7 @@ class Subscriber(MSGClient):
                         self.tasks.append(task)
 
                     else:
-                        loop.call_soon(cb, acknak.values)
+                        loop.call_soon(cb, acknak.value)
 
             # Other msg reads should be from run commands or gets.
             # Check to see if anyone is waiting for a reply.

--- a/saomsg/client.py
+++ b/saomsg/client.py
@@ -161,7 +161,6 @@ class MSGClient(object):
             params = "<None>"
             msg = f"1 {command}\n"
         data = await self._writemsg(msg)
-        print(data)
 
         if int(data[0]) == 1 and data[1] == "ack":
             value = True
@@ -179,14 +178,14 @@ class MSGClient(object):
         msg = "1 lst\n"
         data = await self._writemsg(msg)
         if int(data[0]) == 1 and data[1] == "ack":
-            print("Successfully sent 'lst' command")
+            #print("Successfully sent 'lst' command")
             self.server_info['published'] = list()
             self.server_info['registered'] = list()
             while True:
                 rawdata = await self.reader.readline()
                 line = rawdata.decode()
                 if "----LIST----" in line:
-                    print("Done processing lst output.")
+                    #print("Done processing lst output.")
                     break
                 if 'server' in line:
                     self.server_info['name'] = line.split()[1]
@@ -368,7 +367,7 @@ class Subscriber(MSGClient):
 
         self.writer.write(msg.encode())
         await self.writer.drain()
-        print("getting")
+
         if timeout:
             resp = await asyncio.wait_for( aq.get(), timeout)
         else:

--- a/saomsg/msgtoindi.py
+++ b/saomsg/msgtoindi.py
@@ -1,0 +1,528 @@
+from pyindi.device import device, stdio
+import logging
+from .client import Subscriber
+import asyncio
+import inspect
+from typing import Callable
+import functools
+import sys
+import traceback
+import inspect
+import os
+import asyncio
+from pathlib import Path
+import datetime
+from typing import Union
+import time
+import functools
+import copy
+logging.getLogger().setLevel(logging.DEBUG)
+
+
+INDI_LOG_PATH = os.environ.get("INDI_LOG_PATH")
+if INDI_LOG_PATH:
+    now = datetime.datetime.now()
+    timestr = now.strftime("%H%M%S-%a")
+    log_path = Path(INDI_LOG_PATH)
+    logging.basicConfig(
+        format="%(asctime)-15s %(message)s",
+        filename=log_path/f'{timestr}.log',
+        level=logging.DEBUG
+    )
+    
+
+class wrapper:
+    """This class contains the method wrapper que.
+    when a msg_device method is decorated with a
+    classmethod defined here, the method is sent
+    to a que for processing by the msg_device
+    """
+
+    device = None
+    que = asyncio.Queue()
+
+    def __init__(self):
+        raise NotImplementedError(
+                "There is no reason to instantiate this class. It is used as a namespace"
+                )
+
+    @classmethod
+    def subscribe(cls, device, *items):
+        """
+        Decorating with this method will automatically
+        subscribe to the msg published item and call
+        the decorated method when the item is published.
+        """
+
+        def handle_fxn(fxn):
+            cls.que.put_nowait(('sub', fxn, items))
+        return handle_fxn
+
+
+
+class msg_device(device):
+
+    def __init__(self, msg_server, msg_port, name, **kwargs):
+
+        self.startstop_que = asyncio.Queue()
+
+        self.msg_server = msg_server
+        self.msg_port = msg_port
+        self._name = name
+        self.msg_client = Subscriber(self.msg_server, self.msg_port)
+        self.msgget_que = asyncio.Queue()
+        self.started = -1
+        self._asynctasks_que = asyncio.Queue()
+        self._asynctasks = []
+
+        self._handlers = dict(
+                    subscriptions={}
+                )
+        while 1:
+            try:
+                action, fxn,  items = wrapper.que.get_nowait()
+                if action == 'sub':
+                    for item in items:
+                        self._handlers['subscriptions'][item] = fxn
+
+                else:
+                    raise ValueError(f"action cannot be {action}")
+
+            except asyncio.QueueEmpty:
+                break
+
+        super().__init__(name=self._name, **kwargs)
+
+    def handle(self, item, fxn):
+
+        self._handlers['subscriptions'][item] = fxn
+ 
+
+    async def repeat_queuer(self):
+        while self.running:
+            func = await self.repeat_q.get()
+            try:
+                if inspect.iscoroutinefunction(func):
+                    await func(self)
+                else:
+                    func(self)
+
+            except Exception as error:
+                self.IDMessage(f"There was an error running {func}: {error}")
+                #also push it to stderr
+                sys.stderr.write(
+                    f"There was an exception the \
+                    later decorated fxn {func}:")
+
+                sys.stderr.write(f"{error}")
+                sys.stderr.write("See traceback below.")
+                traceback.print_exc(file=sys.stderr)
+                sys.stderr.flush()
+
+
+    def do_it_async(self, coro):
+        """
+        Arguments:
+        coro an async coroutine insance
+        Bridge between async and non-async world.
+        Sends the async coroutine to asynctasks_que
+        to be scheduled and waits for a response.
+        The response should come almost instantly.
+        If it doesn't, we raise an exception.
+        """
+
+        resp_que = asyncio.Queue()
+        self._asynctasks_que.put_nowait(
+                (coro, resp_que)
+                )
+
+        start=time.time()
+        while 1:
+            try:
+                resp_que.get()
+            except asyncio.QueueEmpty():
+                # Don't block event loop more than
+                # 0.1 seconds
+                if (time.time() - start) > 0.1:
+                    raise RuntimeError(
+                            f"resp_que did not respond in a timely manner for {coro}"
+                            )
+
+                
+
+
+    async def run_async(self):
+        """Schedule tasks from do_it_async
+        and respond with task instance.
+        """
+        while True:
+
+            foo = await self._asynctasks_que.get()
+            if hasattr(foo, "__iter__"):
+                coro,resp_que = foo
+            else:
+                raise RuntimeError(f"something wrong with asynctasks_que output. {foo}")
+            task = asyncio.create_task(coro)
+            self._asynctasks.append(task)
+            await resp_que.put(task)
+
+    def ISGetProperties(self, device=None):
+        vec = self.vectorFactory(
+            "defSwitch",
+            dict(
+                device=self.device,
+                name="CONNECTION",
+                state="Idle",
+                rule="OneOfMany",
+                perm='rw',
+                label="Connect",
+                group="Main"
+            ),
+            [
+                dict(
+                    name="CONNECT",
+                    label="Connect",
+                    state="Off"
+                ), 
+                dict(
+                    name="DISCONNECT",
+                    label="Disconnect",
+                    state="On"
+                )
+            ]
+        )
+        self.IDDef(vec)
+
+
+    
+    async def startstop(self):
+        while True:
+            start = await self.startstop_que.get()
+                    
+            if start:
+                if self.msg_client.running:
+                    logging.debug("Tried to start when already running")
+                else:
+                    self.IDMessage(f"Connecting to msg_client")
+                    await self.msg_client.open()
+                    if self.running == False:
+                        raise RuntimeError("Could not connect to msg server.")
+                    
+                    task = asyncio.create_task(self.msg_client.mainloop())
+                    self.IDMessage("Building property\n")
+                    await self.buildProperties()
+
+            else:
+                if self.msg_client.running:
+                    await self.msg_client.stop()
+                    
+                else:
+                    logging.debug("Tried to stop when stopped.")
+                
+            
+    
+
+    async def asyncInitProperties(self, device=None):
+        self.IDMessage("called async init")
+        if self.msg_client.running:
+            await self.buildProperties()
+
+
+    async def do_the_getting(self):
+        while self.running:
+            msg_name = await self.msgget_que.get()
+            
+            value = await self.msg_client.get(msg_name)
+            vec = self.IUFind(msg_name)
+            button = self.IUFind(f"{msg_name}_getorsub")
+            button[f"get_{msg_name}"].value = "Off"
+            if button.state != "Ok":
+                button.state = "Idle"
+            
+            if type(value) in (list, tuple):
+                vec[msg_name].value = " ".join(value)
+            elif type(value) in (str, int, float):
+                vec[msg_name].value = value
+            else:
+                raise ValueError(f"unknown msg value of type {type(value)}")
+
+            self.IDSet(vec)
+            self.IDSet(button)
+
+
+    async def astart(self):
+        """Start up in async mode"""
+
+        self.mainloop = asyncio.get_running_loop()
+        self.reader, self.writer = await stdio()
+        self.running = True
+        future = asyncio.gather(
+            self.run(),
+            self.toindiserver(),
+            self.repeat_queuer(),
+	    self.do_the_getting(),
+            self.run_async(),
+            self.startstop()
+        )
+        await future
+ 
+    def whats_changed(self, name, values, names, device=None):
+        vec = self.IUFind(name, device=device)
+        changed = {}
+        for val, name in zip(values, names):
+            if vec[name].value != val:
+                changed[name] = val
+
+        return vec, changed
+
+
+    @device.NewVectorProperty("CONNECTION")
+    def connect(self, device, name, states, names):
+        vec, change = self.whats_changed(
+                name, 
+                states, 
+                names, 
+                device)
+        
+        for key, val in change.items():
+            self.IDMessage(f"Setting {key} to {val}")
+
+        if "CONNECT" in change:
+            if change["CONNECT"] == "On":
+                self.IDMessage("Connecting to msg server")
+                self.startstop_que.put_nowait(True)
+                vec['CONNECT'].value = "On"
+                vec['DISCONNECT'].value = "Off"
+                vec.state = "Ok"
+            else:
+                self.startstop_que.put_nowait(False)
+                vec["CONNECT"].value == "Off"
+                vec["DISCONNECT"].value == "On"
+                vec.state == "Idle"
+
+        elif "DISCONNECT" in change:
+            if change["DISCONNECT"] == "On":
+                self.startstop_que.put_nowait(False) 
+                vec['DISCONNECT'].value = "On"
+                vec['CONNECT'].value = "Off"
+                vec.state = "Idle"
+
+            else:
+                self.startstop_que.put_nowait(True) 
+                vec['DISCONNECT'].value = "Off"
+                vec['CONNECT'].value = "On"
+                vec.state="Ok"
+
+        self.IDSet(vec)
+
+
+
+    def ISNewSwitch(self, device, name, values, names):
+        vec = self.IUFind(name)
+        if len(values) > 1:
+            self.IDMessage("More than one get or subscribe bailing")
+            return
+
+        names = names[0]
+        do_what, with_what= names.split('_',1)
+        self.IDMessage(names)
+        if do_what == "subscribe":
+            self.IDMessage(f"Attempting to subscibe to {with_what}")
+            if with_what not in \
+                    self.msg_client.server_info['subscribed']:
+                self.IDMessage(f"Subscribing to {with_what}")
+                self.msg_client.subscribe(
+                        with_what, 
+                        lambda value: self.sub_callback(with_what, value)
+                        )
+                vec.state = "Ok"
+                vec[names].value="On"
+                self.IDSet(vec)
+
+            else:
+                self.IDMessage(f"Already subscribed to {with_what}")
+        elif do_what == "get":
+            self.msgget_que.put_nowait(with_what)
+
+        else:
+            self.IDMessage("Not valid {do_what}")
+                        
+    def sub_callback(self, name, value):
+        self.IDMessage(f"Setting {name} to {value}")
+        vec = self.IUFind(name)
+        vec[name] = value[0]
+        self.IDSet(vec)
+
+
+    async def buildProperties(self):
+        """
+        Build the INDI vectors for values found
+        in the msg client
+        """
+        self.IDMessage("buildProperties called.")
+        
+        hds = self._handlers['subscriptions']
+        for item in self.msg_client.server_info["published"]:
+            logging.debug("onto item {item}")
+            if item in hds.keys():
+                
+                self.IDMessage(f"SUBSCRIBING TO {item}")
+                
+                # I am not going to lie. The next line of code 
+                # should be sent back to hell from whence it 
+                # came but it does work. 
+                fxn = lambda val, item=item: hds[item](self, item, val)
+
+                functools.update_wrapper(fxn, hds[item])
+                self.msg_client.subscribe(
+                        item, 
+                        fxn
+                        )
+
+            #build default get and subscribe stuff.
+            value_def = dict(
+                    device=self._devname,
+                    name=item,
+                    label=item,
+                    group="published",
+                    perm='ro', 
+                    state="Idle",
+                    timeout="0",
+                    )
+
+            value_prop = dict(
+                    name=item,
+                    label=item,
+                    value=""
+                    )
+
+            value_vector = self.vectorFactory(
+                    "defTextVector", 
+                    value_def, 
+                    [value_prop]
+                    )
+
+            self.IDDef(value_vector)
+
+            button_def= dict(
+                    device=self._devname,
+                    name=f"{item}_getorsub",
+                    label=item,
+                    group="buttons",
+                    perm='rw', 
+                    state="Idle",
+                    rule="OneOfMany",
+                    timeout="0",
+                    )
+
+            get_switch = dict(
+                    name=f"get_{item}",
+                    label="get",
+                    value=""
+                    ) 
+
+            sub_switch = dict(
+                    name=f"subscribe_{item}",
+                    label="Subscribe",
+                    value=""
+                    )
+
+            button_vector = self.vectorFactory(
+                    "defSwitchVector", 
+                    button_def, 
+                    [get_switch, sub_switch]
+                    )
+            self.IDDef(button_vector)
+        logging.debug("Finished building properties")
+
+
+
+    @device.repeat(1000)
+    async def idle_tasks(self):
+        conn = self.IUFind("CONNECTION")
+        if self.msg_client.running:  
+            if conn["CONNECT"].value == "Off":
+                conn["CONNECT"].value = "On"
+                conn["DISCONNECT"].value = "Off"
+                conn.state="Idle"
+                self.IDSet(conn)
+
+        else:
+            if conn["CONNECT"].value == "On":
+                self.IDMessage("we are not connected to msg_client")
+                conn["CONNECT"].value = "Off"
+                conn["DISCONNECT"].value = "On"
+                conn.state="Idle"
+                self.IDSet(conn)
+          
+
+
+    @classmethod
+    def subscribe(cls, value):
+        def handle_fxn(fxn):
+            return fxn
+
+        return handle_fxn
+
+#    async def repeat_queuer(self):
+#        while self.running:
+#            func = await self.repeat_q.get()
+#            if self.started > 0:
+#                self.started-=1
+#            elif self.started == 0:
+#                self.IDMessage("SUBSCRIBING")
+#                self.msg_client.subscribe("vTemp", self.show)
+#                
+#            print(f"calling func")
+#            try:
+#                if inspect.iscoroutinefunction(func):
+#                    await func(self)
+#                else:
+#                    func(self)
+#
+#            except Exception as error:
+#                sys.stderr.write(
+#                    f"There was an exception the \
+#                    later decorated fxn {func}:")
+#
+#                sys.stderr.write(f"{error}")
+#                sys.stderr.write("See traceback below.")
+#                traceback.print_exc(file=sys.stderr)
+
+
+
+        
+
+#class PMAC(device):
+#
+#        
+#
+#    def ISGetProperties(self, *args):
+#        print("getProperties")
+#        #pmac = saomsg.Subscriber('localhost', 10100)
+#
+#    async def qwatch(self):
+#        while 1:
+#            data=await self.q.get()
+#            print(data)
+#
+#    @device.repeat(1000)
+#    def repeater(self):
+#
+#        print('sync repeat')
+#
+#    @device.repeat(1500)
+#    async def foobar(self):
+#        """FOOBAR docstring"""
+#        await asyncio.sleep(0.1)
+#        print('async repeat')
+
+
+
+
+
+
+	
+
+
+

--- a/saomsg/tests/test_client.py
+++ b/saomsg/tests/test_client.py
@@ -81,6 +81,7 @@ async def test_bogosity():
     await c.close()
 
 
+
 @pytest.mark.asyncio
 async def test_noconnection():
     cc = MSGClient(host="localhost", port=6869)

--- a/saomsg/tests/test_client.py
+++ b/saomsg/tests/test_client.py
@@ -81,7 +81,6 @@ async def test_bogosity():
     await c.close()
 
 
-
 @pytest.mark.asyncio
 async def test_noconnection():
     cc = MSGClient(host="localhost", port=6869)

--- a/saomsg/tests/test_subscriber.py
+++ b/saomsg/tests/test_subscriber.py
@@ -11,13 +11,13 @@ async def test_client():
     assert(c.server_info['name'] == "TESTSRV")
     await c.close()
 
+
 @pytest.mark.asyncio
 async def test_mainloop():
     c = Subscriber()
     await c.open()
     mtask = asyncio.create_task(c.mainloop())
     assert(c.server_info['name'] == "TESTSRV")
-
 
     bar = await c.get("bar")
     assert(bar[0] == "baz")
@@ -26,9 +26,10 @@ async def test_mainloop():
     assert(long_str == ["there", "once", "was", "a", "man"])
 
     q = asyncio.Queue()
-    def callback( value):
+
+    def callback(value):
         q.put_nowait(value)
-    
+
     c.subscribe("foo", callback)
     await c.run("multiply", "4", "5")
     subscribed_value = await q.get()
@@ -45,6 +46,3 @@ async def test_mainloop():
     # mainloop task.
     await asyncio.sleep(1.0)
     assert (mtask.done())
-
-
-

--- a/saomsg/tests/test_subscriber.py
+++ b/saomsg/tests/test_subscriber.py
@@ -1,0 +1,50 @@
+import pytest
+
+from ..client import Subscriber
+import asyncio
+
+
+@pytest.mark.asyncio
+async def test_client():
+    c = Subscriber()
+    await c.open()
+    assert(c.server_info['name'] == "TESTSRV")
+    await c.close()
+
+@pytest.mark.asyncio
+async def test_mainloop():
+    c = Subscriber()
+    await c.open()
+    mtask = asyncio.create_task(c.mainloop())
+    assert(c.server_info['name'] == "TESTSRV")
+
+
+    bar = await c.get("bar")
+    assert(bar[0] == "baz")
+
+    long_str = await c.get("bazz")
+    assert(long_str == ["there", "once", "was", "a", "man"])
+
+    q = asyncio.Queue()
+    def callback( value):
+        q.put_nowait(value)
+    
+    c.subscribe("foo", callback)
+    await c.run("multiply", "4", "5")
+    subscribed_value = await q.get()
+
+    assert(subscribed_value is not None)
+    assert(int(subscribed_value[0]) == 20)
+
+    await c.close()
+
+    # Give the mainloop a second to close.
+    # It would be nice if this were
+    # determinisitic but we would
+    # have to have more control of the
+    # mainloop task.
+    await asyncio.sleep(1.0)
+    assert (mtask.done())
+
+
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,9 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     astropy
+	pyindi @ git+https://github.com/MMTObservatory/pyINDI
+
+	
 
 
 [options.extras_require]


### PR DESCRIPTION
This pull request adds couple of classes to the client.py module. Nothing from the original MSGClient class has changed. The new Subscriber allows you to map callbacks to data coming in from the msg server based on msgid or subscription parameter. It does this with a run-forever async method called mainloop that reads from the MSG server. 

I have also added an msgtoindi module that converts the MSG stuff to an INDI driver. By default it gives you get and subscribe buttons for each parameter and ignores the registered commands. You can subclass the msg_device class and add functionality. My favorite addition to this module is a wrapper class that allows you to subscribe to MSG parameters with a decorator. It works like this:

```python
@wrapper.subscribe("<INDIDEVICE>", "<MSG_PARAM1>,"  "<MSG_PARAM2>")
def on_msg_subscribe(item, value):
  *Change the item value in the indi driver.*
```
A good example is the [WAVESERV indi driver in example_clients](example_clients/waveserv.py)
