### PR TITLE
Fix tests and workflow

### DIFF
--- a/.github/workflows/saomsg-tests.yml
+++ b/.github/workflows/saomsg-tests.yml
@@ -4,7 +4,13 @@
 
 name: Python Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main  # GitHub now defaults to 'main' as the name of the primary branch.
+  pull_request:
+    branches: # only build on PRs against 'main'
+    - main
 
 jobs:
 
@@ -15,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-ver: [8, 9]
-        tox-env: [cov, astropylts, astropydev, numpydev]
+        tox-env: [cov, astropylts, astropydev]
     steps:
     - uses: actions/checkout@v2
     - name: Set up python 3.${{ matrix.python-ver }} with tox environment ${{ matrix.tox-env }} on ${{ matrix.os }}
@@ -33,7 +39,7 @@ jobs:
         tox -e py3${{ matrix.python-ver }}-${{ matrix.tox-env }}
     - name: Upload coverage to codecov
       if: matrix.tox-env == 'cov' && matrix.python-ver == '8'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV }}
         file: ./coverage.xml

--- a/.github/workflows/saomsg-tests.yml
+++ b/.github/workflows/saomsg-tests.yml
@@ -4,7 +4,7 @@
 
 name: Python Tests
 
-on: push
+on: [push, pull_request]
 
 jobs:
 
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-ver: [7, 8]
+        python-ver: [8, 9]
         tox-env: [cov, astropylts, astropydev, numpydev]
     steps:
     - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Python to test links in docs with sphinx
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: 3.9
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
@@ -64,7 +64,7 @@ jobs:
     - name: Set up Python to build docs with sphinx
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: 3.9
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
@@ -81,7 +81,7 @@ jobs:
     - name: Python codestyle check
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: 3.9
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{37,38}{,-test}{,-cov}
-    py{37,38}-astropylts
-    py{37,38}-{numpy,astropy}dev
+    py{38,39}{,-test}{,-cov}
+    py{38,39}-astropylts
+    py{38,39}-{numpy,astropy}dev
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
This PR fixes test config to limit it to python 3.8 and 3.9. Dependencies aren't quite ready for 3.10 yet. The workflow is updated to match and configured to run on `pull_request` as well as `push`.